### PR TITLE
Add diff foreground rendering and code-style controls

### DIFF
--- a/Benchmarks/ChromaBenchmarks/ChromaBenchmarks.swift
+++ b/Benchmarks/ChromaBenchmarks/ChromaBenchmarks.swift
@@ -39,7 +39,7 @@ let curatedSwiftTokens = try! BenchmarkSupport.tokenize(curatedSwift, language: 
 let curatedDiffTokens = try! BenchmarkSupport.tokenize(curatedDiff, language: .swift, registry: registry)
 
 let defaultOptions = HighlightOptions()
-let diffOptions = HighlightOptions(diff: .patch)
+let diffOptions = HighlightOptions(diff: .patch())
 
 let shouldPrintMetrics = ProcessInfo.processInfo.environment["CHROMA_BENCH_PRINT_METRICS"] == "1"
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ let output = try Chroma.highlight(
 
 ### Diff highlighting (unified patch)
 
-`Chroma` can highlight `+` / `-` lines with green / red background, following the common `git diff` patch rules.
+`Chroma` can highlight `+` / `-` lines in unified patches, following the common `git diff` patch rules.
 
 ```swift
 let patch = """
@@ -111,9 +111,39 @@ index 1111111..2222222 100644
 let output = try Chroma.highlight(
     patch,
     language: .swift,
-    options: .init(diff: .patch)
+    options: .init(diff: .patch())
 )
 print(output)
+```
+
+Foreground-only diff (plain text, no token styling):
+
+```swift
+let output = try Chroma.highlight(
+    patch,
+    language: .swift,
+    options: .init(diff: .patch(style: .foreground()))
+)
+```
+
+Foreground diff with syntax-highlighted context lines:
+
+```swift
+let output = try Chroma.highlight(
+    patch,
+    language: .swift,
+    options: .init(diff: .patch(style: .foreground(contextCode: .syntax)))
+)
+```
+
+Background diff without code styling:
+
+```swift
+let output = try Chroma.highlight(
+    patch,
+    language: .swift,
+    options: .init(diff: .patch(style: .background(diffCode: .plain)))
+)
 ```
 
 ## Custom languages

--- a/Sources/Chroma/HighlightOptions.swift
+++ b/Sources/Chroma/HighlightOptions.swift
@@ -1,8 +1,18 @@
 public struct HighlightOptions: Equatable {
+    public enum DiffCodeStyle: Equatable {
+        case syntax
+        case plain
+    }
+
+    public enum DiffStyle: Equatable {
+        case background(diffCode: DiffCodeStyle = .syntax, contextCode: DiffCodeStyle = .syntax)
+        case foreground(contextCode: DiffCodeStyle = .plain)
+    }
+
     public enum DiffHighlight: Equatable {
         case none
-        case auto
-        case patch
+        case auto(style: DiffStyle = .background())
+        case patch(style: DiffStyle = .background())
     }
 
     public var theme: Theme?
@@ -18,7 +28,7 @@ public struct HighlightOptions: Equatable {
 
     public init(
         theme: Theme? = nil,
-        diff: DiffHighlight = .auto,
+        diff: DiffHighlight = .auto(),
         highlightLines: LineRangeSet = .init(),
         indent: Int = 0
     ) {
@@ -26,5 +36,76 @@ public struct HighlightOptions: Equatable {
         self.diff = diff
         self.highlightLines = highlightLines
         self.indent = max(0, indent)
+    }
+}
+
+extension HighlightOptions {
+    struct DiffRendering: Equatable {
+        let style: DiffStyle
+    }
+
+    var maySkipTokenization: Bool {
+        switch diff {
+        case .none:
+            return false
+        case let .auto(style), let .patch(style):
+            return style.diffCodeStyle == .plain && style.contextCodeStyle == .plain
+        }
+    }
+
+    func diffRendering(for code: String) -> DiffRendering? {
+        diff.rendering(for: code)
+    }
+
+    func shouldSkipTokenization(for code: String) -> Bool {
+        guard let rendering = diffRendering(for: code) else { return false }
+        let style = rendering.style
+        return style.diffCodeStyle == .plain && style.contextCodeStyle == .plain
+    }
+}
+
+extension HighlightOptions.DiffHighlight {
+    func rendering(for code: String) -> HighlightOptions.DiffRendering? {
+        switch self {
+        case .none:
+            return nil
+        case let .patch(style):
+            return HighlightOptions.DiffRendering(style: style)
+        case let .auto(style):
+            guard DiffDetector.looksLikePatch(code) else { return nil }
+            return HighlightOptions.DiffRendering(style: style)
+        }
+    }
+
+    func rendering(for lines: [Substring]) -> HighlightOptions.DiffRendering? {
+        switch self {
+        case .none:
+            return nil
+        case let .patch(style):
+            return HighlightOptions.DiffRendering(style: style)
+        case let .auto(style):
+            guard DiffDetector.looksLikePatch(lines: lines) else { return nil }
+            return HighlightOptions.DiffRendering(style: style)
+        }
+    }
+}
+
+extension HighlightOptions.DiffStyle {
+    var diffCodeStyle: HighlightOptions.DiffCodeStyle {
+        switch self {
+        case let .background(diffCode, _):
+            return diffCode
+        case .foreground:
+            return .plain
+        }
+    }
+
+    var contextCodeStyle: HighlightOptions.DiffCodeStyle {
+        switch self {
+        case let .background(_, contextCode):
+            return contextCode
+        case let .foreground(contextCode):
+            return contextCode
+        }
     }
 }

--- a/Sources/Chroma/Highlighter.swift
+++ b/Sources/Chroma/Highlighter.swift
@@ -24,8 +24,13 @@ public final class Highlighter {
         }
 
         let theme = options.theme ?? self.theme
-        let tokenizer = RegexTokenizer(rules: language.rules, fastPath: language.fastPath)
         let renderer = Renderer(theme: theme, options: options)
+        if options.maySkipTokenization && options.shouldSkipTokenization(for: code) {
+            let ns = code as NSString
+            let tokens = [Token(kind: .plain, range: NSRange(location: 0, length: ns.length))]
+            return renderer.render(code: code, tokens: tokens)
+        }
+        let tokenizer = RegexTokenizer(rules: language.rules, fastPath: language.fastPath)
         return renderer.render(code: code) { emit in
             tokenizer.scan(code, emit: emit)
         }

--- a/Sources/Chroma/TextStyle.swift
+++ b/Sources/Chroma/TextStyle.swift
@@ -15,13 +15,16 @@ public struct TextStyle: Equatable {
         self.styles = styles
     }
 
-    func makeSegment(text: String, backgroundOverride: BackgroundColorType? = nil) -> Rainbow.Segment {
+    func makeSegment(
+        text: String,
+        foregroundOverride: ColorType? = nil,
+        backgroundOverride: BackgroundColorType? = nil
+    ) -> Rainbow.Segment {
         Rainbow.Segment(
             text: text,
-            color: foreground,
+            color: foregroundOverride ?? foreground,
             backgroundColor: backgroundOverride ?? background,
             styles: styles
         )
     }
 }
-

--- a/Sources/Chroma/Theme.swift
+++ b/Sources/Chroma/Theme.swift
@@ -13,18 +13,28 @@ public struct Theme: Equatable {
     /// Background used by `HighlightOptions.diff` for removed lines.
     public var diffRemovedBackground: BackgroundColorType
 
+    /// Foreground used by `HighlightOptions.diff` for added lines.
+    public var diffAddedForeground: ColorType
+
+    /// Foreground used by `HighlightOptions.diff` for removed lines.
+    public var diffRemovedForeground: ColorType
+
     public init(
         name: String,
         tokenStyles: [TokenKind: TextStyle],
         lineHighlightBackground: BackgroundColorType,
         diffAddedBackground: BackgroundColorType,
-        diffRemovedBackground: BackgroundColorType
+        diffRemovedBackground: BackgroundColorType,
+        diffAddedForeground: ColorType,
+        diffRemovedForeground: ColorType
     ) {
         self.name = name
         self.tokenStyles = tokenStyles
         self.lineHighlightBackground = lineHighlightBackground
         self.diffAddedBackground = diffAddedBackground
         self.diffRemovedBackground = diffRemovedBackground
+        self.diffAddedForeground = diffAddedForeground
+        self.diffRemovedForeground = diffRemovedForeground
     }
 
     public func style(for kind: TokenKind) -> TextStyle {
@@ -69,7 +79,9 @@ public extension Theme {
         ],
         lineHighlightBackground: .named(.lightBlack),
         diffAddedBackground: .named(.green),
-        diffRemovedBackground: .named(.red)
+        diffRemovedBackground: .named(.red),
+        diffAddedForeground: .named(.lightGreen),
+        diffRemovedForeground: .named(.lightRed)
     )
 
     static let light = Theme(
@@ -88,6 +100,8 @@ public extension Theme {
         ],
         lineHighlightBackground: .named(.lightYellow),
         diffAddedBackground: .named(.lightGreen),
-        diffRemovedBackground: .named(.lightRed)
+        diffRemovedBackground: .named(.lightRed),
+        diffAddedForeground: .named(.green),
+        diffRemovedForeground: .named(.red)
     )
 }

--- a/Sources/ChromaDemo/ChromaDemo.swift
+++ b/Sources/ChromaDemo/ChromaDemo.swift
@@ -178,7 +178,23 @@ struct ChromaDemo {
                 print(try highlighter.highlight(
                     Samples.patch,
                     language: .swift,
-                    options: .init(diff: .patch)
+                    options: .init(diff: .patch())
+                ))
+                print("")
+
+                printSection("Diff Highlighting (foreground)")
+                print(try highlighter.highlight(
+                    Samples.patch,
+                    language: .swift,
+                    options: .init(diff: .patch(style: .foreground()))
+                ))
+                print("")
+
+                printSection("Diff Highlighting (background, plain code)")
+                print(try highlighter.highlight(
+                    Samples.patch,
+                    language: .swift,
+                    options: .init(diff: .patch(style: .background(diffCode: .plain)))
                 ))
                 print("")
 

--- a/Tests/ChromaTests/ChromaTests.swift
+++ b/Tests/ChromaTests/ChromaTests.swift
@@ -34,7 +34,9 @@ struct HighlighterOutputTests {
             ],
             lineHighlightBackground: .named(.lightYellow),
             diffAddedBackground: .named(.lightGreen),
-            diffRemovedBackground: .named(.lightRed)
+            diffRemovedBackground: .named(.lightRed),
+            diffAddedForeground: .named(.green),
+            diffRemovedForeground: .named(.red)
         )
         let output = try highlightWithTestTheme(
             "// comment",
@@ -77,7 +79,7 @@ struct HighlighterOutputTests {
         let output = try highlightWithTestTheme(
             patch,
             language: .swift,
-            options: .init(diff: .patch)
+            options: .init(diff: .patch())
         )
 
         let expectedAdded = renderExpected([

--- a/Tests/ChromaTests/HighlightOptionsTests.swift
+++ b/Tests/ChromaTests/HighlightOptionsTests.swift
@@ -7,7 +7,7 @@ struct HighlightOptionsTests {
     func defaults() {
         let options = HighlightOptions()
         #expect(options.theme == nil)
-        #expect(options.diff == .auto)
+        #expect(options.diff == .auto())
         #expect(options.highlightLines == LineRangeSet())
         #expect(options.indent == 0)
     }

--- a/Tests/ChromaTests/PerformanceTests.swift
+++ b/Tests/ChromaTests/PerformanceTests.swift
@@ -52,7 +52,7 @@ struct PerformanceTests {
         _ = try highlightWithTestTheme(
             code,
             language: .swift,
-            options: .init(diff: .patch)
+            options: .init(diff: .patch())
         )
         let elapsed = clock.now - start
 

--- a/Tests/ChromaTests/Support/TestSupport.swift
+++ b/Tests/ChromaTests/Support/TestSupport.swift
@@ -19,18 +19,27 @@ enum TestThemes {
         ],
         lineHighlightBackground: .named(.lightYellow),
         diffAddedBackground: .named(.lightGreen),
-        diffRemovedBackground: .named(.lightRed)
+        diffRemovedBackground: .named(.lightRed),
+        diffAddedForeground: .named(.green),
+        diffRemovedForeground: .named(.red)
     )
 }
 
 struct ExpectedToken: Equatable {
     let kind: TokenKind
     let text: String
+    let foreground: ColorType?
     let background: BackgroundColorType?
 
-    init(_ kind: TokenKind, _ text: String, background: BackgroundColorType? = nil) {
+    init(
+        _ kind: TokenKind,
+        _ text: String,
+        foreground: ColorType? = nil,
+        background: BackgroundColorType? = nil
+    ) {
         self.kind = kind
         self.text = text
+        self.foreground = foreground
         self.background = background
     }
 
@@ -53,7 +62,11 @@ private enum RainbowTestState {
 func renderExpected(_ tokens: [ExpectedToken], theme: Theme = TestThemes.stable) -> String {
     ensureRainbowEnabled()
     let segments = tokens.map { token in
-        theme.style(for: token.kind).makeSegment(text: token.text, backgroundOverride: token.background)
+        theme.style(for: token.kind).makeSegment(
+            text: token.text,
+            foregroundOverride: token.foreground,
+            backgroundOverride: token.background
+        )
     }
     return AnsiStringGenerator.generate(for: Rainbow.Entry(segments: segments))
 }

--- a/Tests/ChromaTests/TextStyleTests.swift
+++ b/Tests/ChromaTests/TextStyleTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite("TextStyle")
 struct TextStyleTests {
-    @Test("makeSegment respects background override")
+    @Test("makeSegment respects overrides")
     func backgroundOverride() {
         let style = TextStyle(
             foreground: .named(.red),
@@ -12,10 +12,14 @@ struct TextStyleTests {
             styles: [.bold]
         )
 
-        let segment = style.makeSegment(text: "hi", backgroundOverride: .named(.green))
+        let segment = style.makeSegment(
+            text: "hi",
+            foregroundOverride: .named(.yellow),
+            backgroundOverride: .named(.green)
+        )
 
         #expect(segment.text == "hi")
-        #expect(segment.color == .named(.red))
+        #expect(segment.color == .named(.yellow))
         #expect(segment.backgroundColor == .named(.green))
         #expect(segment.styles == [.bold])
     }

--- a/Tests/ChromaTests/ThemeTests.swift
+++ b/Tests/ChromaTests/ThemeTests.swift
@@ -13,7 +13,9 @@ struct ThemeTests {
             ],
             lineHighlightBackground: .named(.lightYellow),
             diffAddedBackground: .named(.lightGreen),
-            diffRemovedBackground: .named(.lightRed)
+            diffRemovedBackground: .named(.lightRed),
+            diffAddedForeground: .named(.green),
+            diffRemovedForeground: .named(.red)
         )
 
         let style = theme.style(for: .keyword)


### PR DESCRIPTION
## Summary
- add diff foreground rendering and diff/context code-style controls
- skip tokenization when diff rendering is plain, and avoid unnecessary line splits
- extend theme diff colors, demos, and tests for all diff style combinations

## Testing
- swift test

## Notes
- Highlight Swift (Rainbow on) benchmark restored after diff detection optimization