### PR TITLE
Add diff mode to ca config

### DIFF
--- a/Sources/CaCore/CaCommand.swift
+++ b/Sources/CaCore/CaCommand.swift
@@ -66,7 +66,7 @@ package struct CaCommand: AsyncParsableCommand {
                 }
 
                 let theme = resolver.resolve(using: perFileConfig)
-                let highlighter = HighlighterService(theme: theme, lineNumbers: perFileConfig.lineNumbers)
+                let highlighter = HighlighterService(theme: theme, lineNumbers: perFileConfig.lineNumbers, diff: perFileConfig.diff)
                 documents.append(try highlighter.render(input))
             }
 

--- a/Sources/CaCore/CaConfig.swift
+++ b/Sources/CaCore/CaConfig.swift
@@ -30,6 +30,7 @@ struct CaConfig: Equatable {
 
         struct Overrides: Equatable {
             var lineNumbers: Bool?
+            var diff: DiffMode?
             var themeName: String?
             var themeAppearance: ThemeAppearancePreference?
         }
@@ -42,6 +43,9 @@ struct CaConfig: Equatable {
             if let lineNumbers = overrides.lineNumbers {
                 config.lineNumbers = lineNumbers
             }
+            if let diff = overrides.diff {
+                config.diff = diff
+            }
             if let name = overrides.themeName {
                 config.theme.name = name
             }
@@ -53,6 +57,7 @@ struct CaConfig: Equatable {
 
     var theme: ThemeSelection
     var lineNumbers: Bool
+    var diff: DiffMode
     var paging: PagingMode
     var headers: Bool
     var rules: [Rule]
@@ -60,6 +65,7 @@ struct CaConfig: Equatable {
     static let `default` = CaConfig(
         theme: .init(name: nil, appearance: .auto),
         lineNumbers: true,
+        diff: .auto,
         paging: .auto,
         headers: true,
         rules: []
@@ -77,6 +83,15 @@ struct CaConfig: Equatable {
     }
 }
 
+
+
+enum DiffMode: String, CaseIterable, Codable {
+    case auto
+    case none
+    case patch
+}
+
+extension DiffMode: ExpressibleByArgument {}
 enum ThemeAppearancePreference: String, Codable {
     case auto
     case dark

--- a/Sources/CaCore/ConfigLoader.swift
+++ b/Sources/CaCore/ConfigLoader.swift
@@ -26,6 +26,7 @@ struct CaConfigLoader {
 private struct CaConfigFile: Decodable {
     var theme: Theme?
     var lineNumbers: Bool?
+    var diff: DiffMode?
     var paging: PagingMode?
     var headers: Bool?
     var rules: [Rule]?
@@ -71,10 +72,12 @@ private struct CaConfigFile: Decodable {
 
         struct Set: Decodable {
             var lineNumbers: Bool?
+            var diff: DiffMode?
             var theme: Theme?
 
             enum CodingKeys: String, CodingKey {
                 case lineNumbers
+                case diff
                 case theme
             }
         }
@@ -99,6 +102,9 @@ private struct CaConfigFile: Decodable {
         if let lineNumbers {
             config.lineNumbers = lineNumbers
         }
+        if let diff {
+            config.diff = diff
+        }
         if let paging {
             config.paging = paging
         }
@@ -112,6 +118,7 @@ private struct CaConfigFile: Decodable {
                     match: .init(ext: Set(rule.match.ext.map { $0.lowercased() })),
                     overrides: .init(
                         lineNumbers: rule.set.lineNumbers,
+                        diff: rule.set.diff,
                         themeName: rule.set.theme?.name,
                         themeAppearance: rule.set.theme?.appearance
                     )

--- a/Sources/CaCore/HighlighterService.swift
+++ b/Sources/CaCore/HighlighterService.swift
@@ -10,15 +10,28 @@ struct HighlighterService {
     private let highlighter: Highlighter
     private let options: HighlightOptions
 
-    init(theme: Theme, lineNumbers: Bool) {
+    init(theme: Theme, lineNumbers: Bool, diff: DiffMode) {
         self.highlighter = Highlighter(theme: theme)
         self.options = HighlightOptions(
             colorMode: .auto(output: .stdout),
             missingLanguageHandling: .fallbackToPlainText,
+            diff: Self.mapDiff(diff),
             lineNumbers: lineNumbers ? LineNumberOptions() : .none
         )
     }
 
+
+
+    private static func mapDiff(_ mode: DiffMode) -> HighlightOptions.DiffHighlight {
+        switch mode {
+        case .auto:
+            return .auto()
+        case .none:
+            return .none
+        case .patch:
+            return .patch()
+        }
+    }
     func render(_ input: InputFile) throws -> HighlightedDocument {
         let output = try highlighter.highlight(
             input.content,


### PR DESCRIPTION
## What
Add a `diff` switch to `ca` config (`~/.config/ca/config.json`), with per-extension overrides via `rules`.

Supported values:
- `"auto"` (default)
- `"none"`
- `"patch"`

## Why
We want to be able to disable diff rendering for patch files (e.g. show the full raw patch, including meta/header lines), while keeping the default behavior intact.

## Tests
- Added `Per-extension diff override` integration test in `CaTests`.
